### PR TITLE
feat: Add check for DIST and LENGTH to LIC6 / LIC0

### DIFF
--- a/src/main/java/LIC.java
+++ b/src/main/java/LIC.java
@@ -1,6 +1,7 @@
 public class LIC {
 
     public static boolean LIC0(int numPoints, Point[] points, Parameters p) {
+        if (p.LENGTH1 < 0) return false;
         for (int i = 0; i < numPoints - 1; i++) {
             if (Point.distance(points[i], points[i + 1]) > p.LENGTH1)
                 return true;
@@ -41,8 +42,8 @@ public class LIC {
     }
 
     public static boolean LIC6(int numPoints, Point[] points, Parameters p) {
-        if (numPoints < 3 || p.N_PTS < 3 || p.DIST < 0 || numPoints < p.N_PTS)
-            return false;
+        if (numPoints < 3 || p.N_PTS < 3 || p.DIST < 0 || numPoints < p.N_PTS ||
+            p.DIST < 0) return false;
 
         for (int i = 0; i <= numPoints - p.N_PTS; i++) {
             Point p_start = points[i];

--- a/src/test/java/LICTests.java
+++ b/src/test/java/LICTests.java
@@ -100,6 +100,15 @@ public class LICTests {
     }
 
     @Test
+    // Contract: LIC0 is false iff LENGTH1 < 0
+    void LIC0_false_with_length_too_small() {
+        Parameters p = new Parameters();
+        p.LENGTH1 = -1;
+        Point[] pts = { new Point(0, 0), new Point(3, 4)};
+        assertFalse(LIC.LIC0(pts.length, pts, p));
+    }
+
+    @Test
     void testLIC1() {
         Parameters p = new Parameters();
         p.RADIUS1 = 3;
@@ -286,8 +295,28 @@ public class LICTests {
                 new Point(0, 0),
                 new Point(1, 0)
         };
-        assertFalse(LIC.LIC6(2, points3, p));
+        assertFalse(LIC.LIC6(points3.length, points3, p));
+    }
 
+     @Test
+    public void LIC6_false_with_DIST_too_small() {
+        // Contract: LIC6 is false iff DIST < 0
+        Parameters p = new Parameters();
+        p.N_PTS = 3;
+        p.DIST = -1;
+        Point[] points3 = new Point[] {
+                new Point(0, 0),
+                new Point(1, 0),
+                new Point(2, 0),
+                new Point(1, 1),
+                new Point(2, 2),
+                new Point(1, 1),
+                new Point(0, 3),
+                new Point(1, 2),
+                new Point(6, 0),
+                new Point(1, -1)
+        };
+        assertFalse(LIC.LIC6(points3.length, points3, p));
     }
 
     @Test


### PR DESCRIPTION
Add check and test for LENGTH1 in LIC0, and for DIST in LIC6. Closes #77