### PR TITLE
fix: add check if area < 0 LIC10

### DIFF
--- a/src/main/java/LIC.java
+++ b/src/main/java/LIC.java
@@ -152,7 +152,8 @@ public class LIC {
     }
 
     public static boolean LIC10(int numPoints, Point[] points, Parameters p) {
-        if (numPoints < 5 || p.E_PTS < 1 ||p.F_PTS < 1 || p.E_PTS + p.F_PTS > numPoints - 3) return false;
+        if (numPoints < 5 || p.E_PTS < 1 ||p.F_PTS < 1 || p.E_PTS + p.F_PTS > numPoints - 3 ||
+            p.AREA1 < 0) return false;
 
         for (int i = 0; i < numPoints - p.F_PTS - p.E_PTS - 2; i ++) {
             Point p1 = points[i];

--- a/src/test/java/LICTests.java
+++ b/src/test/java/LICTests.java
@@ -801,7 +801,7 @@ public class LICTests {
 
     @Test
     public void LIC10_false_when_too_few_points() {
-        // Contract: LIC10 is false iff less than 5 points are being passed
+        // Contract: LIC10 is false if less than 5 points are being passed
         Point [] points = new Point[] {
                 new Point(1, 0),
                 new Point(0, 0),
@@ -815,8 +815,23 @@ public class LICTests {
     }
 
     @Test
+    public void LIC10_false_when_area_too_small() {
+        // Contract: LIC10 is false if the area is smaller than 0
+        Point [] points = new Point[] {
+                new Point(1, 0),
+                new Point(0, 0),
+                new Point(1, 0)
+        };
+        Parameters p = new Parameters();
+        p.E_PTS = 2;
+        p.F_PTS = 2;
+        p.AREA1 = -1;
+        assertFalse(LIC.LIC10(3, points, p));
+    }
+
+    @Test
     public void LIC10_false_when_EPTS_plus_FTPS_too_large() {
-        // Contract: LIC10 is false iff E_PTS + F_PTS <= numpoints - 3
+        // Contract: LIC10 is false if E_PTS + F_PTS <= numpoints - 3
         Point [] points = new Point[] {
                 new Point(1, 0),
                 new Point(0, 0),


### PR DESCRIPTION
Add a check in the LIC10 function if the area is smaller than 0. Add a corresponding test. 
Closes #154 